### PR TITLE
Fix the image source variable call

### DIFF
--- a/src/partials/profile.html
+++ b/src/partials/profile.html
@@ -2,7 +2,7 @@
     <div class="card profile-card"><span class="profile-pic-container">
       <div class="profile-pic">
         {{#if r.info.image}}
-        <img data-src="holder.js/100x100" alt="{{{r.name}}}" src="{{r.info.image}}" itemprop="image" class="media-object img-circle center-block"/>
+        <img data-src="holder.js/100x100" alt="{{{r.name}}}" src="{{{r.info.image}}}" itemprop="image" class="media-object img-circle center-block"/>
         {{/if}}
       </div>
       <div class="name-and-profession text-center"><h3 itemprop="name"><b>{{{r.name}}}</b></h3><h5 itemprop="jobTitle" class="text-muted">{{r.info.label}}</h5></div></span>


### PR DESCRIPTION
Not displaying the raw variable causes URLs and some paths not to be displayed correctly.